### PR TITLE
Register C++ tests with CTest, fix CMake test setup, and run tests via ctest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,29 +11,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # リポジトリのチェックアウト
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # 必要なツールをインストール
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake g++ make
 
-      # プロジェクトをビルド
-      - name: Build project
+      - name: Configure and build
         run: |
-          mkdir -p build
-          cd build
-          cmake ..
-          cmake --build .
+          cmake -S . -B build
+          cmake --build build
 
-      # list.txt からテストを実行
-      - name: Run all tests from list.txt
+      - name: Run C++ unit tests
         run: |
-          cd build
-          while read TEST; do
-            echo "Running $TEST"
-            ./test_$TEST || exit 1
-          done < ../list.txt
+          ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(DoubleSumChecker)
 
 # C++の標準バージョン
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# テストを有効化
+enable_testing()
 
 # ライブラリのビルド
 add_library(DoubleSumChecker STATIC
@@ -12,16 +16,11 @@ add_library(DoubleSumChecker STATIC
 )
 
 # テストケースリストファイルを読み込む
-file(STRINGS "list.txt" FILES)
-
-foreach(FILE ${TEST_FILES})
-    add_library(src/${FILE}.cpp)
-endforeach()
-
 file(STRINGS "list.txt" TEST_FILES)
 
 foreach(TEST_NAME ${TEST_FILES})
     message(STATUS "Registering test case: ${TEST_NAME}")
     add_executable(test_${TEST_NAME} tests/test_${TEST_NAME}.cpp)
-    target_link_libraries(test_${TEST_NAME} DoubleSumChecker)
+    target_link_libraries(test_${TEST_NAME} PRIVATE DoubleSumChecker)
+    add_test(NAME test_${TEST_NAME} COMMAND test_${TEST_NAME})
 endforeach()

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
 # DoubleSumChecker
 
-https://shakayami.hatenablog.com/entry/2021/01/01/044946
+参考記事: https://shakayami.hatenablog.com/entry/2021/01/01/044946
+
+## 現在の実装状況
+- C++ 実装: `list.txt` にある 12 種類（Add/Sub/Multiply/Const/Projection/DiffSquare/Min/Max/DiffAbs/Xor/And/Or）
+- C++ 単体テスト: `tests/` に各実装ごとのテストを用意
+- CI: GitHub Actions で CMake + CTest を実行
+
+## 今後のタスク分解（全制覇に向けたロードマップ）
+
+### Phase 1: C++ 基盤の安定化
+1. CMake/CTest を唯一のテスト実行経路として固定
+2. `list.txt` と `tests/` の整合性チェックを追加（欠落テスト検出）
+3. 失敗時に最小反例が分かるよう、テスト出力を改善
+
+### Phase 2: 問題網羅（C++）
+1. 参考記事にある式変形パターンを表形式で列挙
+2. 未実装パターンを `src/` に追加
+3. 同数のテストを `tests/` に追加して回帰防止
+
+### Phase 3: 多言語展開（競技プログラミング主要言語）
+対象候補:
+- Python
+- Rust
+- Go
+- Java
+- Kotlin
+
+進め方:
+1. 各言語で「同一I/O仕様」の CLI を作成
+2. 共通テストベクトル（JSON/TSV）を定義
+3. 言語ごとにラッパーを用意して同一ケースで検証
+
+### Phase 4: マルチ言語 CI
+1. GitHub Actions のジョブを言語別に分離（失敗箇所を明確化）
+2. 共通テストデータで C++/Python/Rust/Go/Java/Kotlin を横断実行
+3. 実行時間短縮のためキャッシュ（pip/cargo/go build/maven）を導入
+
+### Phase 5: 品質強化
+1. ランダムテスト（プロパティベーステスト）を追加
+2. ベンチマークを導入して競プロ制約を満たすことを確認
+3. ドキュメントに「実装済み/未実装マトリクス」を公開


### PR DESCRIPTION
### Motivation
- CTest reported "No tests were found" because tests were not registered with CTest and the previous CMake loop was incorrect. 
- CI was running tests via a custom script instead of the standard `ctest` flow, so the workflow needed to be aligned with CMake/CTest. 
- Provide a clear roadmap and current status in `README.md` to drive future multi-language and coverage work.

### Description
- Enable CTest in `CMakeLists.txt` by adding `enable_testing()` and register each test with `add_test(...)` so CMake-produced executables are discoverable by `ctest`. 
- Remove the broken/unused loop that attempted to create libraries from `list.txt` and set test targets to link `DoubleSumChecker` with `target_link_libraries(... PRIVATE ...)`. 
- Update GitHub Actions workflow (`.github/workflows/ci.yml`) to use `actions/checkout@v4`, configure with `cmake -S . -B build`, build with `cmake --build build`, and run tests using `ctest --test-dir build --output-on-failure`. 
- Extend `README.md` with the current implementation status and a phased roadmap (Phase 1..5) toward full coverage and multi-language CI support.

### Testing
- Ran `cmake -S . -B build` to configure the project and `cmake --build build` to compile the library and test executables successfully. 
- Executed `ctest --test-dir build --output-on-failure` and observed all tests pass: `12/12 tests passed, 0 failed`. 
- Changes were committed and validated locally with the above commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7342ade483288bdf39cf9dd13f23)