### PR TITLE
Add CMake consistency checks between list.txt and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,40 @@ add_library(DoubleSumChecker STATIC
 # テストケースリストファイルを読み込む
 file(STRINGS "list.txt" TEST_FILES)
 
+# list.txt と tests/ の整合性チェック（欠落テスト検出）
+file(GLOB TEST_SOURCES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "tests/test_*.cpp")
+set(DISCOVERED_TEST_NAMES "")
+foreach(TEST_SOURCE ${TEST_SOURCES})
+    string(REGEX REPLACE "^tests/test_(.+)\\.cpp$" "\\1" DISCOVERED_TEST_NAME "${TEST_SOURCE}")
+    list(APPEND DISCOVERED_TEST_NAMES "${DISCOVERED_TEST_NAME}")
+endforeach()
+
+set(MISSING_TESTS "")
+foreach(TEST_NAME ${TEST_FILES})
+    set(TEST_SOURCE "tests/test_${TEST_NAME}.cpp")
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_SOURCE}")
+        list(APPEND MISSING_TESTS "${TEST_SOURCE}")
+    endif()
+endforeach()
+
+if(MISSING_TESTS)
+    list(JOIN MISSING_TESTS "\n  - " MISSING_TESTS_JOINED)
+    message(FATAL_ERROR "list.txt に対応するテストファイルが不足しています:\n  - ${MISSING_TESTS_JOINED}")
+endif()
+
+set(UNLISTED_TESTS "")
+foreach(DISCOVERED_TEST_NAME ${DISCOVERED_TEST_NAMES})
+    list(FIND TEST_FILES "${DISCOVERED_TEST_NAME}" TEST_INDEX)
+    if(TEST_INDEX EQUAL -1)
+        list(APPEND UNLISTED_TESTS "tests/test_${DISCOVERED_TEST_NAME}.cpp")
+    endif()
+endforeach()
+
+if(UNLISTED_TESTS)
+    list(JOIN UNLISTED_TESTS "\n  - " UNLISTED_TESTS_JOINED)
+    message(FATAL_ERROR "tests/ にあるが list.txt に未登録のテストファイルがあります:\n  - ${UNLISTED_TESTS_JOINED}")
+endif()
+
 foreach(TEST_NAME ${TEST_FILES})
     message(STATUS "Registering test case: ${TEST_NAME}")
     add_executable(test_${TEST_NAME} tests/test_${TEST_NAME}.cpp)


### PR DESCRIPTION
### Motivation
- Ensure `list.txt` and `tests/` stay in sync as described in README Phase 1 to catch omissions early during configuration. 
- Fail fast at CMake configure time when a discrepancy exists so CI surfaces missing or unregistered tests immediately.

### Description
- Added discovery of `tests/test_*.cpp` via `file(GLOB ...)` and extraction of test names to `DISCOVERED_TEST_NAMES`.
- Added detection of test files referenced in `list.txt` but missing on disk and emit a readable `message(FATAL_ERROR)` listing the missing files. 
- Added detection of `tests/test_*.cpp` files that are not listed in `list.txt` and emit a readable `message(FATAL_ERROR)` listing the unregistered tests. 
- Kept the original loop that registers tests from `list.txt` with `add_executable`, `target_link_libraries`, and `add_test` unchanged.

### Testing
- Ran `cmake -S . -B build` which configured successfully without errors. 
- Ran `cmake --build build` which built the library and all test executables successfully. 
- Ran `ctest --test-dir build --output-on-failure` and all tests passed (`12/12` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad74e55cf48328b88f42163148dd26)