### PR TITLE
Add SumSquareDoubleSumChecker and corresponding test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 参考記事: https://shakayami.hatenablog.com/entry/2021/01/01/044946
 
 ## 現在の実装状況
-- C++ 実装: `list.txt` にある 12 種類（Add/Sub/Multiply/Const/Projection/DiffSquare/Min/Max/DiffAbs/Xor/And/Or）
+- C++ 実装: `list.txt` にある 13 種類（Add/Sub/Multiply/Const/Projection/DiffSquare/Min/Max/DiffAbs/Xor/And/Or/SumSquare）
 - C++ 単体テスト: `tests/` に各実装ごとのテストを用意
 - CI: GitHub Actions で CMake + CTest を実行
 

--- a/list.txt
+++ b/list.txt
@@ -10,3 +10,4 @@ DiffAbsDoubleSumChecker
 XorDoubleSumChecker
 AndDoubleSumChecker
 OrDoubleSumChecker
+SumSquareDoubleSumChecker

--- a/src/SumSquareDoubleSumChecker.cpp
+++ b/src/SumSquareDoubleSumChecker.cpp
@@ -1,0 +1,33 @@
+#ifndef SUMSQUAREDOUBLESUMCHECKER_CPP
+#define SUMSQUAREDOUBLESUMCHECKER_CPP
+
+#include "AbstractDoubleSumChecker.cpp"
+#include <random>
+
+class SumSquareDoubleSumChecker : public AbstractDoubleSumChecker<long long> {
+    using T = long long;
+
+    T func(T x, T y) override {
+        return (x + y) * (x + y);
+    }
+
+    T SolveFasterAlgorithm(const std::vector<T>& A) override {
+        const int N = static_cast<int>(A.size());
+        T sum = 0;
+        T squareSum = 0;
+        for (const auto& val : A) {
+            sum += val;
+            squareSum += val * val;
+        }
+        return (N - 2) * squareSum + sum * sum;
+    }
+
+    T RandomElementGenerator() override {
+        static std::random_device seed_gen;
+        static std::mt19937 engine(seed_gen());
+        std::uniform_int_distribution<T> dist(0, 1000000);
+        return dist(engine);
+    }
+};
+
+#endif // SUMSQUAREDOUBLESUMCHECKER_CPP

--- a/tests/test_SumSquareDoubleSumChecker.cpp
+++ b/tests/test_SumSquareDoubleSumChecker.cpp
@@ -1,0 +1,14 @@
+#include "../src/SumSquareDoubleSumChecker.cpp"
+#include <iostream>
+
+int main() {
+    SumSquareDoubleSumChecker checker;
+
+    if (checker.Verification()) {
+        std::cout << "SumSquareDoubleSumChecker Test Passed" << std::endl;
+        return 0;
+    } else {
+        std::cerr << "SumSquareDoubleSumChecker Test Failed" << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
### Motivation
- Cover an additional expression pattern from the reference (pairwise `(x+y)^2`) so the project reaches broader problem coverage.
- Provide a faster closed-form computation to validate correctness and performance against the naive pairwise sum check.

### Description
- Added `src/SumSquareDoubleSumChecker.cpp` which implements `func(x,y)=(x+y)^2` and a `SolveFasterAlgorithm` using the identity `(N-2)\sum a_i^2 + (\sum a_i)^2`.
- Added unit test `tests/test_SumSquareDoubleSumChecker.cpp` which uses `Verification()` to compare the naive and faster implementations.
- Registered the new checker in `list.txt` so CMake auto-discovers and runs the test, and updated `README.md` to reflect the increased implementation count.

### Testing
- Ran full configure/build and tests with `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`.
- All tests passed: `13/13` tests succeeded (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad765bd1288328ac0208e3a68df551)