### PR TITLE
Add SquareSumDoubleSumChecker and verification test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 参考記事: https://shakayami.hatenablog.com/entry/2021/01/01/044946
 
 ## 現在の実装状況
-- C++ 実装: `list.txt` にある 12 種類（Add/Sub/Multiply/Const/Projection/DiffSquare/Min/Max/DiffAbs/Xor/And/Or）
+- C++ 実装: `list.txt` にある 13 種類（Add/Sub/Multiply/Const/Projection/DiffSquare/Min/Max/DiffAbs/Xor/And/Or/SquareSum）
 - C++ 単体テスト: `tests/` に各実装ごとのテストを用意
 - CI: GitHub Actions で CMake + CTest を実行
 

--- a/list.txt
+++ b/list.txt
@@ -10,3 +10,4 @@ DiffAbsDoubleSumChecker
 XorDoubleSumChecker
 AndDoubleSumChecker
 OrDoubleSumChecker
+SquareSumDoubleSumChecker

--- a/src/SquareSumDoubleSumChecker.cpp
+++ b/src/SquareSumDoubleSumChecker.cpp
@@ -1,0 +1,31 @@
+#ifndef SQUARESUMDOUBLESUMCHECKER_CPP
+#define SQUARESUMDOUBLESUMCHECKER_CPP
+
+#include "AbstractDoubleSumChecker.cpp"
+#include <random>
+
+class SquareSumDoubleSumChecker : public AbstractDoubleSumChecker<long long> {
+    using T = long long;
+
+    T func(T x, T y) override {
+        return x * x + y * y;
+    }
+
+    T SolveFasterAlgorithm(const std::vector<T>& A) override {
+        const int N = static_cast<int>(A.size());
+        T sumSquares = 0;
+        for (const auto& val : A) {
+            sumSquares += val * val;
+        }
+        return (N - 1) * sumSquares;
+    }
+
+    T RandomElementGenerator() override {
+        static std::random_device seed_gen;
+        static std::mt19937 engine(seed_gen());
+        std::uniform_int_distribution<T> dist(0, 1000000000);
+        return dist(engine);
+    }
+};
+
+#endif // SQUARESUMDOUBLESUMCHECKER_CPP

--- a/tests/test_SquareSumDoubleSumChecker.cpp
+++ b/tests/test_SquareSumDoubleSumChecker.cpp
@@ -1,0 +1,14 @@
+#include "../src/SquareSumDoubleSumChecker.cpp"
+#include <iostream>
+
+int main() {
+    SquareSumDoubleSumChecker checker;
+
+    if (checker.Verification()) {
+        std::cout << "SquareSumDoubleSumChecker Test Passed" << std::endl;
+        return 0;
+    } else {
+        std::cerr << "SquareSumDoubleSumChecker Test Failed" << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
### Motivation
- Add support for the new problem where `f(x,y) = x^2 + y^2` and provide a faster closed-form algorithm for pairwise sums to expand the checker coverage.

### Description
- Added `src/SquareSumDoubleSumChecker.cpp` implementing `func` and `SolveFasterAlgorithm` using the identity `(N-1) * sum_i(a_i^2)`.
- Added test `tests/test_SquareSumDoubleSumChecker.cpp` which calls `Verification()` to compare naive and faster algorithms.
- Registered the new checker by appending `SquareSumDoubleSumChecker` to `list.txt`.
- Updated `README.md` to reflect the implementation count increasing to 13.

### Testing
- Ran `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure` to build the project and run the full test suite.
- All tests passed: 13/13 tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad765bd1288328ac0208e3a68df551)