### PR TITLE
Add GCD and equality double-sum implementations

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -10,3 +10,5 @@ DiffAbsDoubleSumChecker
 XorDoubleSumChecker
 AndDoubleSumChecker
 OrDoubleSumChecker
+GcdDoubleSumChecker
+EqualDoubleSumChecker

--- a/src/EqualDoubleSumChecker.cpp
+++ b/src/EqualDoubleSumChecker.cpp
@@ -1,0 +1,39 @@
+#ifndef EQUALDOUBLESUMCHECKER_CPP
+#define EQUALDOUBLESUMCHECKER_CPP
+
+#include "AbstractDoubleSumChecker.cpp"
+#include <random>
+#include <unordered_map>
+
+class EqualDoubleSumChecker : public AbstractDoubleSumChecker<long long> {
+    using T = long long;
+
+    T func(T x, T y) override {
+        return x == y ? 1 : 0;
+    }
+
+    T SolveFasterAlgorithm(const std::vector<T>& A) override {
+        std::unordered_map<T, T> frequency;
+        frequency.reserve(A.size() * 2);
+
+        for (const T value : A) {
+            ++frequency[value];
+        }
+
+        T result = 0;
+        for (const auto& [value, count] : frequency) {
+            (void)value;
+            result += count * (count - 1) / 2;
+        }
+        return result;
+    }
+
+    T RandomElementGenerator() override {
+        static std::random_device seed_gen;
+        static std::mt19937 engine(seed_gen());
+        std::uniform_int_distribution<T> dist(1, 400);
+        return dist(engine);
+    }
+};
+
+#endif // EQUALDOUBLESUMCHECKER_CPP

--- a/src/GcdDoubleSumChecker.cpp
+++ b/src/GcdDoubleSumChecker.cpp
@@ -1,0 +1,57 @@
+#ifndef GCDDOUBLESUMCHECKER_CPP
+#define GCDDOUBLESUMCHECKER_CPP
+
+#include "AbstractDoubleSumChecker.cpp"
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <vector>
+
+class GcdDoubleSumChecker : public AbstractDoubleSumChecker<long long> {
+    using T = long long;
+
+    T func(T x, T y) override {
+        return std::gcd(x, y);
+    }
+
+    T SolveFasterAlgorithm(const std::vector<T>& A) override {
+        if (A.empty()) {
+            return 0;
+        }
+
+        const T maxValue = *std::max_element(A.begin(), A.end());
+        std::vector<T> count(maxValue + 1, 0);
+        for (const T value : A) {
+            ++count[value];
+        }
+
+        std::vector<T> exactPairCount(maxValue + 1, 0);
+        T result = 0;
+
+        for (T g = maxValue; g >= 1; --g) {
+            T multipleCount = 0;
+            for (T x = g; x <= maxValue; x += g) {
+                multipleCount += count[x];
+            }
+
+            T pairCount = multipleCount * (multipleCount - 1) / 2;
+            for (T x = g * 2; x <= maxValue; x += g) {
+                pairCount -= exactPairCount[x];
+            }
+
+            exactPairCount[g] = pairCount;
+            result += g * pairCount;
+        }
+
+        return result;
+    }
+
+    T RandomElementGenerator() override {
+        static std::random_device seed_gen;
+        static std::mt19937 engine(seed_gen());
+        std::uniform_int_distribution<T> dist(1, 200000);
+        return dist(engine);
+    }
+};
+
+#endif // GCDDOUBLESUMCHECKER_CPP

--- a/tests/test_EqualDoubleSumChecker.cpp
+++ b/tests/test_EqualDoubleSumChecker.cpp
@@ -1,0 +1,14 @@
+#include "../src/EqualDoubleSumChecker.cpp"
+#include <iostream>
+
+int main() {
+    EqualDoubleSumChecker checker;
+
+    if (checker.Verification()) {
+        std::cout << "EqualDoubleSumChecker Test Passed" << std::endl;
+        return 0;
+    } else {
+        std::cerr << "EqualDoubleSumChecker Test Failed" << std::endl;
+        return 1;
+    }
+}

--- a/tests/test_GcdDoubleSumChecker.cpp
+++ b/tests/test_GcdDoubleSumChecker.cpp
@@ -1,0 +1,14 @@
+#include "../src/GcdDoubleSumChecker.cpp"
+#include <iostream>
+
+int main() {
+    GcdDoubleSumChecker checker;
+
+    if (checker.Verification()) {
+        std::cout << "GcdDoubleSumChecker Test Passed" << std::endl;
+        return 0;
+    } else {
+        std::cerr << "GcdDoubleSumChecker Test Failed" << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
### Motivation
- Expand the set of implemented double-sum problems to cover more patterns from the reference problem family and Phase 2 roadmap.  
- Provide efficient (sub-quadratic) algorithms for two new pairwise-sum functions so they can be validated against the naive implementation.  
- Attempted to fetch the referenced blog but the environment returned `403`, so implementation followed the project pattern for adding new checkers and tests.

### Description
- Added `src/GcdDoubleSumChecker.cpp` which implements `func(x,y)=gcd(x,y)` and a faster algorithm that counts multiples per value and uses inclusion–exclusion over gcd values to compute the contribution.  
- Added `src/EqualDoubleSumChecker.cpp` which implements `func(x,y)=1` when `x==y` and a faster algorithm that sums `c*(c-1)/2` over value frequencies.  
- Added tests `tests/test_GcdDoubleSumChecker.cpp` and `tests/test_EqualDoubleSumChecker.cpp` and registered both names in `list.txt` so CMake/CTest will discover them.  

### Testing
- Ran a full configure/build/test flow with `cmake -S . -B build`, `cmake --build build` and `ctest --test-dir build --output-on-failure`.  
- All tests passed: `100% tests passed, 0 tests failed` (14/14).  
- Verified the new test binaries were built and executed successfully during the CTest run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad765bd1288328ac0208e3a68df551)