### PR TITLE
Add NAND and NOR double-sum checkers with verification tests

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -10,3 +10,5 @@ DiffAbsDoubleSumChecker
 XorDoubleSumChecker
 AndDoubleSumChecker
 OrDoubleSumChecker
+NandDoubleSumChecker
+NorDoubleSumChecker

--- a/src/NandDoubleSumChecker.cpp
+++ b/src/NandDoubleSumChecker.cpp
@@ -1,0 +1,40 @@
+#ifndef NANDDOUBLESUMCHECKER_CPP
+#define NANDDOUBLESUMCHECKER_CPP
+
+#include "AbstractDoubleSumChecker.cpp"
+#include <random>
+
+class NandDoubleSumChecker : public AbstractDoubleSumChecker<long long> {
+    using T = long long;
+    static constexpr T MASK = (1LL << 30) - 1;
+
+    T func(T x, T y) override {
+        return (~(x & y)) & MASK;
+    }
+
+    T SolveFasterAlgorithm(const std::vector<T>& A) override {
+        const int N = static_cast<int>(A.size());
+        T result = 0;
+        for (int k = 0; k < 30; ++k) {
+            T ones = 0;
+            for (int i = 0; i < N; ++i) {
+                if ((A[i] >> k) & 1LL) {
+                    ++ones;
+                }
+            }
+            const T zeros = N - ones;
+            const T pairs_and_zero = zeros * (zeros - 1) / 2 + ones * zeros;
+            result += pairs_and_zero << k;
+        }
+        return result;
+    }
+
+    T RandomElementGenerator() override {
+        static std::random_device seed_gen;
+        static std::mt19937 engine(seed_gen());
+        std::uniform_int_distribution<T> dist(0, 1000000000);
+        return dist(engine);
+    }
+};
+
+#endif // NANDDOUBLESUMCHECKER_CPP

--- a/src/NorDoubleSumChecker.cpp
+++ b/src/NorDoubleSumChecker.cpp
@@ -1,0 +1,39 @@
+#ifndef NORDOUBLESUMCHECKER_CPP
+#define NORDOUBLESUMCHECKER_CPP
+
+#include "AbstractDoubleSumChecker.cpp"
+#include <random>
+
+class NorDoubleSumChecker : public AbstractDoubleSumChecker<long long> {
+    using T = long long;
+    static constexpr T MASK = (1LL << 30) - 1;
+
+    T func(T x, T y) override {
+        return (~(x | y)) & MASK;
+    }
+
+    T SolveFasterAlgorithm(const std::vector<T>& A) override {
+        const int N = static_cast<int>(A.size());
+        T result = 0;
+        for (int k = 0; k < 30; ++k) {
+            T zeros = 0;
+            for (int i = 0; i < N; ++i) {
+                if (((A[i] >> k) & 1LL) == 0) {
+                    ++zeros;
+                }
+            }
+            const T pairs_or_zero = zeros * (zeros - 1) / 2;
+            result += pairs_or_zero << k;
+        }
+        return result;
+    }
+
+    T RandomElementGenerator() override {
+        static std::random_device seed_gen;
+        static std::mt19937 engine(seed_gen());
+        std::uniform_int_distribution<T> dist(0, 1000000000);
+        return dist(engine);
+    }
+};
+
+#endif // NORDOUBLESUMCHECKER_CPP

--- a/tests/test_NandDoubleSumChecker.cpp
+++ b/tests/test_NandDoubleSumChecker.cpp
@@ -1,0 +1,14 @@
+#include "../src/NandDoubleSumChecker.cpp"
+#include <iostream>
+
+int main() {
+    NandDoubleSumChecker checker;
+
+    if (checker.Verification()) {
+        std::cout << "NandDoubleSumChecker Test Passed" << std::endl;
+        return 0;
+    } else {
+        std::cerr << "NandDoubleSumChecker Test Failed" << std::endl;
+        return 1;
+    }
+}

--- a/tests/test_NorDoubleSumChecker.cpp
+++ b/tests/test_NorDoubleSumChecker.cpp
@@ -1,0 +1,14 @@
+#include "../src/NorDoubleSumChecker.cpp"
+#include <iostream>
+
+int main() {
+    NorDoubleSumChecker checker;
+
+    if (checker.Verification()) {
+        std::cout << "NorDoubleSumChecker Test Passed" << std::endl;
+        return 0;
+    } else {
+        std::cerr << "NorDoubleSumChecker Test Failed" << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
### Motivation

- Add missing bitwise-pattern variants (NAND and NOR) to match the reference set of pairwise functions and complete coverage of bitwise operators.
- Provide O(bits * N) per-bit counting algorithms for these functions to verify correctness against the naive O(N^2) baseline in `AbstractDoubleSumChecker`.

### Description

- Added `src/NandDoubleSumChecker.cpp` implementing `func(x,y) = (~(x & y)) & MASK` with a per-bit counting fast algorithm and a 30-bit `MASK` matching the input range.
- Added `src/NorDoubleSumChecker.cpp` implementing `func(x,y) = (~(x | y)) & MASK` with a per-bit counting fast algorithm and the same 30-bit `MASK`.
- Added verification tests `tests/test_NandDoubleSumChecker.cpp` and `tests/test_NorDoubleSumChecker.cpp` and registered both names in `list.txt` so CMake/CTest discover and run them.

### Testing

- Configured, built, and ran the full test suite with `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`, and all tests passed (14/14).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad765bd1288328ac0208e3a68df551)