### PR TITLE
Improve C++ verification diagnostics with minimized counterexamples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 ## 現在の実装状況
 - C++ 実装: `list.txt` にある 13 種類（Add/Sub/Multiply/Const/Projection/DiffSquare/Min/Max/DiffAbs/Xor/And/Or/SquareSum/SumSquare）
-- C++ 単体テスト: `tests/` に各実装ごとのテストを用意
+- C++ 単体テスト: `tests/` に各実装ごとのテストを用意（失敗時に最小反例を表示）
 - CI: GitHub Actions で CMake + CTest を実行
 
 ## 今後のタスク分解（全制覇に向けたロードマップ）
 
-### Phase 1: C++ 基盤の安定化
-1. CMake/CTest を唯一のテスト実行経路として固定
-2. `list.txt` と `tests/` の整合性チェックを追加（欠落テスト検出）
-3. 失敗時に最小反例が分かるよう、テスト出力を改善
+### Phase 1: C++ 基盤の安定化（完了）
+1. ✅ CMake/CTest を唯一のテスト実行経路として固定
+2. ✅ `list.txt` と `tests/` の整合性チェックを追加（欠落テスト検出）
+3. ✅ 失敗時に最小反例が分かるよう、テスト出力を改善
 
 ### Phase 2: 問題網羅（C++）
 1. 参考記事にある式変形パターンを表形式で列挙

--- a/src/AbstractDoubleSumChecker.cpp
+++ b/src/AbstractDoubleSumChecker.cpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <iostream>
+#include <sstream>
 
 template<typename T>
 class AbstractDoubleSumChecker {
@@ -22,14 +23,79 @@ public:
     }
     virtual T SolveFasterAlgorithm(const std::vector<T>& A) = 0;
     virtual T RandomElementGenerator() = 0;
+
+    bool HasMismatch(const std::vector<T>& A, T* ansNaive = nullptr, T* ansFaster = nullptr) {
+        T naive = SolveNaiveAlgorithm(A);
+        T faster = SolveFasterAlgorithm(A);
+        if (ansNaive) {
+            *ansNaive = naive;
+        }
+        if (ansFaster) {
+            *ansFaster = faster;
+        }
+        return naive != faster;
+    }
+
+    std::vector<T> MinimizeCounterExample(const std::vector<T>& source) {
+        std::vector<T> current = source;
+        bool changed = true;
+        while (changed && current.size() > 2) {
+            changed = false;
+            for (size_t i = 0; i < current.size(); ++i) {
+                std::vector<T> candidate;
+                candidate.reserve(current.size() - 1);
+                for (size_t j = 0; j < current.size(); ++j) {
+                    if (j != i) {
+                        candidate.push_back(current[j]);
+                    }
+                }
+                if (HasMismatch(candidate)) {
+                    current = std::move(candidate);
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        return current;
+    }
+
+    std::string FormatArray(const std::vector<T>& A) {
+        std::ostringstream oss;
+        oss << "[";
+        for (size_t i = 0; i < A.size(); ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << A[i];
+        }
+        oss << "]";
+        return oss.str();
+    }
+
     virtual bool Verification(int testSize = 1000) {
         std::vector<T> A(testSize);
         for (int i = 0; i < testSize; ++i) {
             A[i] = RandomElementGenerator();
         }
-        T ansNaive = SolveNaiveAlgorithm(A);
-        T ansFaster = SolveFasterAlgorithm(A);
-        return (ansNaive == ansFaster);
+
+        T ansNaive = 0;
+        T ansFaster = 0;
+        if (!HasMismatch(A, &ansNaive, &ansFaster)) {
+            return true;
+        }
+
+        const std::vector<T> minimized = MinimizeCounterExample(A);
+        T minNaive = 0;
+        T minFaster = 0;
+        HasMismatch(minimized, &minNaive, &minFaster);
+
+        std::cerr << "Verification mismatch detected.\n"
+                  << "  original size: " << A.size() << "\n"
+                  << "  minimized size: " << minimized.size() << "\n"
+                  << "  minimized input: " << FormatArray(minimized) << "\n"
+                  << "  naive answer: " << minNaive << "\n"
+                  << "  faster answer: " << minFaster << std::endl;
+        return false;
     }
 };
 


### PR DESCRIPTION
### Motivation
- Improve debugging of failing verification by printing a compact, human-readable counterexample instead of only returning false.
- Enable automatic minimization of failing random test inputs so root causes are easier to inspect.
- Update documentation to reflect that C++ verification improvements are complete for Phase 1.

### Description
- Add `HasMismatch(const std::vector<T>&, T* ansNaive=nullptr, T* ansFaster=nullptr)` to compute and report whether `SolveNaiveAlgorithm` and `SolveFasterAlgorithm` disagree and optionally capture both results.
- Add `MinimizeCounterExample(const std::vector<T>&)` which greedily removes elements while preserving the mismatch to produce a small failing input.
- Add `FormatArray(const std::vector<T>&)` and update `Verification(int)` to use these helpers and emit detailed diagnostics including original/minimized sizes, minimized input, and both answers to `std::cerr` when a mismatch is found.
- Update `README.md` to mark Phase 1 as completed and note that tests now print minimized counterexamples on failure.

### Testing
- Ran `cmake -S . -B build`, `cmake --build build`, and `ctest --test-dir build --output-on-failure` as the test workflow.
- All tests passed locally: 18/18 tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7e9d029883289a715f2ce55030f2)