### PR TITLE
docs: add pattern matrix and update README roadmap status

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 参考記事: https://shakayami.hatenablog.com/entry/2021/01/01/044946
 
 ## 現在の実装状況
-- C++ 実装: `list.txt` にある 13 種類（Add/Sub/Multiply/Const/Projection/DiffSquare/Min/Max/DiffAbs/Xor/And/Or/SquareSum/SumSquare）
+- C++ 実装: `list.txt` にある 18 種類（Add/Sub/Multiply/Const/Projection/DiffSquare/Min/Max/DiffAbs/Xor/And/Or/Nand/Nor/Gcd/Equal/SquareSum/SumSquare）
 - C++ 単体テスト: `tests/` に各実装ごとのテストを用意（失敗時に最小反例を表示）
 - CI: GitHub Actions で CMake + CTest を実行
 
@@ -15,7 +15,7 @@
 3. ✅ 失敗時に最小反例が分かるよう、テスト出力を改善
 
 ### Phase 2: 問題網羅（C++）
-1. 参考記事にある式変形パターンを表形式で列挙
+1. ✅ 参考記事にある式変形パターンを表形式で列挙（`docs/pattern-matrix.md`）
 2. 未実装パターンを `src/` に追加
 3. 同数のテストを `tests/` に追加して回帰防止
 
@@ -41,3 +41,6 @@
 1. ランダムテスト（プロパティベーステスト）を追加
 2. ベンチマークを導入して競プロ制約を満たすことを確認
 3. ドキュメントに「実装済み/未実装マトリクス」を公開
+
+## 補助ドキュメント
+- 実装済み/未実装マトリクス: `docs/pattern-matrix.md`

--- a/docs/pattern-matrix.md
+++ b/docs/pattern-matrix.md
@@ -1,0 +1,31 @@
+# Pattern Matrix (DoubleSumChecker)
+
+`\sum_{0 \le i < j < N} f(A_i, A_j)` を高速化する既知パターンの一覧です。
+
+| Pattern | `f(x, y)` | 実装 | テスト | 状態 |
+|---|---|---|---|---|
+| Add | `x + y` | `src/AddDoubleSumChecker.cpp` | `tests/test_AddDoubleSumChecker.cpp` | ✅ 実装済み |
+| Sub | `x - y` | `src/SubDoubleSumChecker.cpp` | `tests/test_SubDoubleSumChecker.cpp` | ✅ 実装済み |
+| Multiply | `x * y` | `src/MultiplyDoubleSumChecker.cpp` | `tests/test_MultiplyDoubleSumChecker.cpp` | ✅ 実装済み |
+| Const | `1` | `src/ConstDoubleSumChecker.cpp` | `tests/test_ConstDoubleSumChecker.cpp` | ✅ 実装済み |
+| Projection | `y` | `src/ProjectionDoubleSumChecker.cpp` | `tests/test_ProjectionDoubleSumChecker.cpp` | ✅ 実装済み |
+| DiffSquare | `(x - y)^2` | `src/DiffSquareDoubleSumChecker.cpp` | `tests/test_DiffSquareDoubleSumChecker.cpp` | ✅ 実装済み |
+| Min | `min(x, y)` | `src/MinDoubleSumChecker.cpp` | `tests/test_MinDoubleSumChecker.cpp` | ✅ 実装済み |
+| Max | `max(x, y)` | `src/MaxDoubleSumChecker.cpp` | `tests/test_MaxDoubleSumChecker.cpp` | ✅ 実装済み |
+| DiffAbs | `\|x - y\|` | `src/DiffAbsDoubleSumChecker.cpp` | `tests/test_DiffAbsDoubleSumChecker.cpp` | ✅ 実装済み |
+| Xor | `x ^ y` | `src/XorDoubleSumChecker.cpp` | `tests/test_XorDoubleSumChecker.cpp` | ✅ 実装済み |
+| And | `x & y` | `src/AndDoubleSumChecker.cpp` | `tests/test_AndDoubleSumChecker.cpp` | ✅ 実装済み |
+| Or | `x \| y` | `src/OrDoubleSumChecker.cpp` | `tests/test_OrDoubleSumChecker.cpp` | ✅ 実装済み |
+| Nand | `~(x & y)`（30bit mask） | `src/NandDoubleSumChecker.cpp` | `tests/test_NandDoubleSumChecker.cpp` | ✅ 実装済み |
+| Nor | `~(x \| y)`（30bit mask） | `src/NorDoubleSumChecker.cpp` | `tests/test_NorDoubleSumChecker.cpp` | ✅ 実装済み |
+| Gcd | `gcd(x, y)` | `src/GcdDoubleSumChecker.cpp` | `tests/test_GcdDoubleSumChecker.cpp` | ✅ 実装済み |
+| Equal | `[x == y]` | `src/EqualDoubleSumChecker.cpp` | `tests/test_EqualDoubleSumChecker.cpp` | ✅ 実装済み |
+| SquareSum | `x^2 + y^2` | `src/SquareSumDoubleSumChecker.cpp` | `tests/test_SquareSumDoubleSumChecker.cpp` | ✅ 実装済み |
+| SumSquare | `(x + y)^2` | `src/SumSquareDoubleSumChecker.cpp` | `tests/test_SumSquareDoubleSumChecker.cpp` | ✅ 実装済み |
+
+## 次に進める作業
+
+Phase 2 の残タスク:
+1. 参考記事の追加パターン（もし未収録があれば）を洗い出す
+2. `src/` に実装を追加
+3. `tests/` に対応テストを追加


### PR DESCRIPTION
### Motivation
- Make it explicit which double-sum patterns are implemented in C++ and provide a single reference matrix for maintainers. 
- Update the project roadmap to reflect current progress for Phase 2 and provide a pointer to the new matrix document.

### Description
- Updated `README.md` to report the current C++ implementation count as 18 and mark Phase 2 step 1 complete with a link to the new matrix. 
- Added `docs/pattern-matrix.md` which lists the 18 implemented patterns with `f(x, y)`, implementation file (`src/*.cpp`), corresponding test file (`tests/*`), and implementation status. 
- Clarified next steps for Phase 2 in the matrix file to guide further implementation and testing work.

### Testing
- Configured the project with `cmake -S . -B build` successfully. 
- Built the project with `cmake --build build` with no build errors. 
- Executed the test suite with `ctest --test-dir build --output-on-failure` and observed all 18 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8216df188328b7f93fc0ef5e0ace)