### PR TITLE
Add CubeSumDoubleSumChecker and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 参考記事: https://shakayami.hatenablog.com/entry/2021/01/01/044946
 
 ## 現在の実装状況
-- C++ 実装: `list.txt` にある 18 種類（Add/Sub/Multiply/Const/Projection/DiffSquare/Min/Max/DiffAbs/Xor/And/Or/Nand/Nor/Gcd/Equal/SquareSum/SumSquare）
+- C++ 実装: `list.txt` にある 19 種類（Add/Sub/Multiply/Const/Projection/DiffSquare/Min/Max/DiffAbs/Xor/And/Or/Nand/Nor/Gcd/Equal/SquareSum/SumSquare/CubeSum）
 - C++ 単体テスト: `tests/` に各実装ごとのテストを用意（失敗時に最小反例を表示）
 - CI: GitHub Actions で CMake + CTest を実行
 

--- a/docs/pattern-matrix.md
+++ b/docs/pattern-matrix.md
@@ -22,6 +22,7 @@
 | Equal | `[x == y]` | `src/EqualDoubleSumChecker.cpp` | `tests/test_EqualDoubleSumChecker.cpp` | ✅ 実装済み |
 | SquareSum | `x^2 + y^2` | `src/SquareSumDoubleSumChecker.cpp` | `tests/test_SquareSumDoubleSumChecker.cpp` | ✅ 実装済み |
 | SumSquare | `(x + y)^2` | `src/SumSquareDoubleSumChecker.cpp` | `tests/test_SumSquareDoubleSumChecker.cpp` | ✅ 実装済み |
+| CubeSum | `x^3 + y^3` | `src/CubeSumDoubleSumChecker.cpp` | `tests/test_CubeSumDoubleSumChecker.cpp` | ✅ 実装済み |
 
 ## 次に進める作業
 

--- a/list.txt
+++ b/list.txt
@@ -16,3 +16,4 @@ GcdDoubleSumChecker
 EqualDoubleSumChecker
 SquareSumDoubleSumChecker
 SumSquareDoubleSumChecker
+CubeSumDoubleSumChecker

--- a/src/CubeSumDoubleSumChecker.cpp
+++ b/src/CubeSumDoubleSumChecker.cpp
@@ -1,0 +1,31 @@
+#ifndef CUBESUMDOUBLESUMCHECKER_CPP
+#define CUBESUMDOUBLESUMCHECKER_CPP
+
+#include "AbstractDoubleSumChecker.cpp"
+#include <random>
+
+class CubeSumDoubleSumChecker : public AbstractDoubleSumChecker<long long> {
+    using T = long long;
+
+    T func(T x, T y) override {
+        return x * x * x + y * y * y;
+    }
+
+    T SolveFasterAlgorithm(const std::vector<T>& A) override {
+        const int N = static_cast<int>(A.size());
+        T sumCubes = 0;
+        for (const auto& val : A) {
+            sumCubes += val * val * val;
+        }
+        return (N - 1) * sumCubes;
+    }
+
+    T RandomElementGenerator() override {
+        static std::random_device seed_gen;
+        static std::mt19937 engine(seed_gen());
+        std::uniform_int_distribution<T> dist(0, 10000);
+        return dist(engine);
+    }
+};
+
+#endif // CUBESUMDOUBLESUMCHECKER_CPP

--- a/tests/test_CubeSumDoubleSumChecker.cpp
+++ b/tests/test_CubeSumDoubleSumChecker.cpp
@@ -1,0 +1,14 @@
+#include "../src/CubeSumDoubleSumChecker.cpp"
+#include <iostream>
+
+int main() {
+    CubeSumDoubleSumChecker checker;
+
+    if (checker.Verification()) {
+        std::cout << "CubeSumDoubleSumChecker Test Passed" << std::endl;
+        return 0;
+    } else {
+        std::cerr << "CubeSumDoubleSumChecker Test Failed" << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
### Motivation
- Add support for the CubeSum pattern where f(x, y) = x^3 + y^3 to expand the set of recognized pairwise-sum transformations.
- Keep the tests, documentation, and test registration in sync so CMake/CTest automatically builds and validates the new pattern.

### Description
- Implemented `CubeSumDoubleSumChecker` in `src/CubeSumDoubleSumChecker.cpp` with an O(N) faster algorithm returning `(N-1) * Σ a_i^3` and a bounded random generator.
- Added an executable test `tests/test_CubeSumDoubleSumChecker.cpp` which calls `Verification()` to compare naive and faster results.
- Registered the new checker in `list.txt` so CMake discovers and builds the test automatically.
- Updated `docs/pattern-matrix.md` and `README.md` to document the new CubeSum entry and to reflect the updated implemented count.

### Testing
- Ran the full build and test pipeline with `cmake -S . -B build`, `cmake --build build`, and `ctest --test-dir build --output-on-failure`.
- Result: all tests passed, with `19` tests executed and `0` failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad83438af88328b3db70d853f78dae)