### PR TITLE
go: add SubAgentChecker and tests

### DIFF
--- a/go/agents/agents_test.go
+++ b/go/agents/agents_test.go
@@ -10,6 +10,14 @@ func TestAddAgent(t *testing.T) {
 	}
 }
 
+func TestSubAgent(t *testing.T) {
+	agent := SubAgentChecker{}
+	data := []int64{10, 4, 2, 1}
+	if agent.HasMismatch(data) {
+		t.Fatalf("sub agent mismatch")
+	}
+}
+
 func TestMultiplyAgent(t *testing.T) {
 	agent := MultiplyAgentChecker{}
 	data := []int64{2, 3, 5, 7}

--- a/go/agents/sub_agent.go
+++ b/go/agents/sub_agent.go
@@ -1,0 +1,26 @@
+package agents
+
+type SubAgentChecker struct {
+	BaseChecker
+}
+
+func (s SubAgentChecker) Func(x, y int64) int64 {
+	return x - y
+}
+
+func (s SubAgentChecker) SolveNaiveAlgorithm(values []int64) int64 {
+	return s.BaseChecker.SolveNaiveAlgorithm(values, s.Func)
+}
+
+func (s SubAgentChecker) SolveFasterAlgorithm(values []int64) int64 {
+	var ans int64
+	n := int64(len(values))
+	for i, v := range values {
+		ans += (n - 1 - 2*int64(i)) * v
+	}
+	return ans
+}
+
+func (s SubAgentChecker) HasMismatch(values []int64) bool {
+	return s.SolveNaiveAlgorithm(values) != s.SolveFasterAlgorithm(values)
+}


### PR DESCRIPTION
### Motivation
- Add support for the `f(x, y) = x - y` pattern in the Go agents to match the implementations in other languages and the pattern matrix documentation. 
- Provide unit coverage for the new checker so regressions are detected by language-specific CI.

### Description
- Add `go/agents/sub_agent.go` which implements `SubAgentChecker` with `Func(x,y)`, `SolveNaiveAlgorithm` delegating to `BaseChecker`, `SolveFasterAlgorithm` using the coefficient formula `sum((n-1-2*i)*a[i])`, and `HasMismatch`.
- Update `go/agents/agents_test.go` to include `TestSubAgent` that verifies the fast solver matches the naive solver for a sample vector.

### Testing
- Ran `go test ./...` in the `go/` directory and the tests passed (package `doublesum-go/agents` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adacb8243483288df844f93f6986f6)